### PR TITLE
V1.2 issue fixes and small clean ups

### DIFF
--- a/src/creaturesounds.ts
+++ b/src/creaturesounds.ts
@@ -183,17 +183,14 @@ function scoreSoundSets(actor: ActorPF2e): Map<SoundSet, number> {
         }
         // Trait match 
         const matchingTraits = soundSet.traits.filter((trait: string) => traits.includes(trait));
-        let mainTraitsScore = 0;
-        let genderTraitsScore = 0;
 
         for (const trait of matchingTraits) {
             if (trait === "male" || trait === "female") {
-                genderTraitsScore += GENDER_TRAIT_SCORE;
+                score += GENDER_TRAIT_SCORE;
             } else {
-                mainTraitsScore += TRAIT_SCORE;
+                score += TRAIT_SCORE;
             }
         }
-        score += mainTraitsScore + genderTraitsScore;
 
         // Size adjustment
         if (score > 0 && soundSet.size != -1 && creatureSize != -1) {

--- a/src/creaturesounds.ts
+++ b/src/creaturesounds.ts
@@ -38,6 +38,7 @@ const soundDatabase: SoundDatabase = Object.fromEntries(
 const KEYWORD_NAME_SCORE = 5;
 const KEYWORD_BLURB_SCORE = 4;
 const TRAIT_SCORE = 1;
+const GENDER_TRAIT_SCORE = 0.5;
 
 export const NO_SOUND_SET = "none";
 
@@ -172,9 +173,18 @@ function scoreSoundSets(actor: ActorPF2e): Map<SoundSet, number> {
             }
         }
         // Trait match 
-        const matchingTraits =
-                soundSet.traits.filter((trait: string) => traits.includes(trait)).length;
-        score += matchingTraits * TRAIT_SCORE;
+        const matchingTraits = soundSet.traits.filter((trait: string) => traits.includes(trait));
+        let mainTraitsScore = 0;
+        let genderTraitsScore = 0;
+
+        for (const trait of matchingTraits) {
+            if (trait === "male" || trait === "female") {
+                genderTraitsScore += GENDER_TRAIT_SCORE;
+            } else {
+                mainTraitsScore += TRAIT_SCORE;
+            }
+        }
+        score += mainTraitsScore + genderTraitsScore;
 
         // Size adjustment
         if (score > 0 && soundSet.size != -1 && creatureSize != -1) {

--- a/src/creaturesounds.ts
+++ b/src/creaturesounds.ts
@@ -116,6 +116,15 @@ export async function findSoundSet(actor: ActorPF2e): Promise<SoundSet | null> {
         }
     }
 
+    // If character has they/them pronouns, default to no sound.
+    if (isCharacter(actor)) {
+        const pronouns = actor.system.details.gender.value;
+        if (pronouns?.match(/\b(they|them)\b/i)) {
+            logd("Actor has 'they/them' pronouns, defaulting to no sound.");
+            return null;
+        }
+    }
+
     // Check for exact name match.
     let soundSet = findSoundSetByCreatureName(getActorName(actor));
     if (soundSet) {

--- a/src/ui/actorsoundselect.ts
+++ b/src/ui/actorsoundselect.ts
@@ -1,5 +1,5 @@
 import { findSoundSet, getDbSoundSetNames, NO_SOUND_SET, playSoundForCreature } from "../creaturesounds.ts";
-import { MODULE_ID } from "../utils.ts";
+import { MODULE_ID, truncateStringWithEllipsis } from "../utils.ts";
 import { getSetting, SETTINGS } from "../settings.ts";
 import { ActorPF2e } from "foundry-pf2e";
 import { ApplicationFormConfiguration } from "foundry-pf2e/foundry/client/applications/_types.mjs";
@@ -15,7 +15,7 @@ export class ActorSoundSelectApp extends HandlebarsApplicationMixin(ApplicationV
     constructor(actor: ActorPF2e) {
         super({
             window: {
-                title: "Creature Sounds: " + actor.name
+                title: "Creature Sounds: " + truncateStringWithEllipsis(actor.name, 30)
             }
         });
         this.actor = actor;

--- a/src/ui/customsounds.ts
+++ b/src/ui/customsounds.ts
@@ -325,9 +325,6 @@ export class CustomSoundsApp extends HandlebarsApplicationMixin(ApplicationV2) {
                         return;
                     }
 
-                    console.log(folderPath);
-                    console.log(source);
-
                     const folderContents = await FilePickerClass.browse(source, folderPath);
                     const soundSetFolders = folderContents.dirs;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,3 +95,17 @@ export function getActorName(actor: ActorPF2e): string {
     } 
     return actor.name;
 }
+
+export function truncateStringWithEllipsis(str: string, limit: number): string {
+    if (str.length <= limit) {
+        return str;
+    }
+
+    const ellipsis = "...";
+
+    if (limit <= ellipsis.length) {
+        return str.slice(0, limit);
+    }
+
+    return str.slice(0, limit - ellipsis.length) + ellipsis;
+}


### PR DESCRIPTION
Small clean up of accidental remaining logs

Suggested fix for long name distorting dialog box

Suggested resolution to treat gender matching as a lower score

They/Them pronouns detected on a character should now automatically select no sound, allowing the user to select one that suits them