### PR TITLE
Fix FilePicker version check

### DIFF
--- a/src/ui/customsounds.ts
+++ b/src/ui/customsounds.ts
@@ -8,12 +8,7 @@ import {
     deleteAllCustomSoundSets
 } from "../customsoundsdb.ts";
 
-import { isSoundDatabase } from "../utils.ts";
-
-const FilePickerClass = foundry.utils.isNewerVersion("13", game.version)
-    ? foundry.applications.apps.FilePicker
-    // @ts-expect-error - v12 global FilePicker
-    : FilePicker;
+import { getFilePickerClass, isSoundDatabase } from "../utils.ts";
 
 const { ApplicationV2, HandlebarsApplicationMixin, DialogV2 } = foundry.applications.api;
 interface SoundSetEntry {
@@ -144,7 +139,7 @@ export class CustomSoundsApp extends HandlebarsApplicationMixin(ApplicationV2) {
         }
         const soundType = target.dataset.type as SoundType;
 
-        const fp = new FilePickerClass({
+        const fp = new (getFilePickerClass())({
             title: "Select a sound",
             type: "audio",
             callback: async (path: string) => {
@@ -313,6 +308,7 @@ export class CustomSoundsApp extends HandlebarsApplicationMixin(ApplicationV2) {
             return;
         }
 
+        const FilePickerClass = getFilePickerClass();
         const fp = new FilePickerClass({
             type: "folder",
             title: "Select a folder containing your organized sound set subfolders",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -137,3 +137,10 @@ export function truncateStringWithEllipsis(str: string, limit: number): string {
 
     return str.slice(0, limit - ellipsis.length) + ellipsis;
 }
+
+export function getFilePickerClass() {
+    return foundry.utils.isNewerVersion(game.version, "13")
+        ? foundry.applications.apps.FilePicker
+        // @ts-expect-error - v12 global FilePicker
+        : FilePicker;
+}


### PR DESCRIPTION
Fix an issue where FilePicker version check in the custom sounds dialog was the wrong way round, and in the wrong place.

Turns out `game.version` is not set early during Foundry start, so checking the version here (outside the class) doesn't work.

Instead, moved the check inside a utility method, which is called when a file picker is needed.