### PR TITLE
Multi-trait matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Organise sound sets into categories
 - Added many new sound sets
 - Renamed some sound sets
+- Add multi-trait matching (e.g. for elemental+fire)
 
 ## [1.1.1] - 2025-07-20
 

--- a/databases/creature_sounds_db.json
+++ b/databases/creature_sounds_db.json
@@ -3935,7 +3935,7 @@
             "consonite choir",
             "ledalusca"
         ],
-        "traits": [],
+        "traits": [["elemental", "cold"], ["elemental", "cold", "water"]],
         "size": -1
     },
     "Elemental Fire": {
@@ -3966,8 +3966,8 @@
             "lava worm",
             "xiuh couatl"
         ],
-        "traits": [],
-        "size": -1
+        "traits": [["elemental", "fire"]],
+        "size": 3
     },
     "Elemental Water": {
         "display_name": "Water Elemental (Large)",
@@ -3997,8 +3997,8 @@
             "tidal master",
             "living waterfall"
         ],
-        "traits": [],
-        "size": -1
+        "traits": [["elemental", "water"]],
+        "size": 3
     },
     "Elemental Air": {
         "display_name": "Air Elemental (Large)",
@@ -4030,8 +4030,8 @@
             "bythos",
             "living thunderclap"
         ],
-        "traits": [],
-        "size": -1
+        "traits": [["elemental", "air"]],
+        "size": 3
     },
     "Elemental Earth": {
         "display_name": "Earth Elemental (Large)",
@@ -4068,8 +4068,8 @@
             "living boulder",
             "mudwretch"
         ],
-        "traits": [],
-        "size": -1
+        "traits": [["elemental", "earth"]],
+        "size": 3
     },
     "Insect_Swarm": {
         "display_name": "Swarm - Mosquitoes",
@@ -5102,8 +5102,8 @@
         ],
         "creatures": [],
         "keywords": [],
-        "traits": [],
-        "size": -1
+        "traits": [["elemental", "fire"]],
+        "size": 2
     },
     "Deimavigga": {
         "display_name": "Deimavigga",
@@ -5701,8 +5701,8 @@
         ],
         "creatures": [],
         "keywords": [],
-        "traits": [],
-        "size": -1
+        "traits": [["elemental", "earth"]],
+        "size": 2
     },
     "Shark": {
         "display_name": "Shark",

--- a/src/creaturesounds.ts
+++ b/src/creaturesounds.ts
@@ -38,7 +38,7 @@ export interface SoundSet {
     death_sounds: string[];
     creatures: string[];
     keywords: string[];
-    traits: string[];
+    traits: (string | string[])[];
     size: number;
 }
 
@@ -62,8 +62,14 @@ const soundDatabase: SoundDatabase = Object.fromEntries(
 // Score values
 const KEYWORD_NAME_SCORE = 5;
 const KEYWORD_BLURB_SCORE = 4;
-const TRAIT_SCORE = 1;
-const GENDER_TRAIT_SCORE = 0.5;
+
+// Trait Scoring
+const TRAIT_WEIGHT = 1.0;
+const GENDER_TRAIT_WEIGHT = 0.5;
+const TRAIT_SET_BASE_SCORE = 0.9;
+const TRAIT_SET_PER_TRAIT_SCORE = 0.1;
+const TRAIT_SET_MAX_SCORE = 1.9;
+const TRAIT_SET_SIZE_BONUS = 0.1;
 
 export const NO_SOUND_SET = "none";
 
@@ -216,15 +222,35 @@ export function scoreSoundSets(actor: ActorPF2e, db: SoundDatabase = soundDataba
                 score += KEYWORD_BLURB_SCORE;
             }
         }
-        // Trait match 
-        const matchingTraits = soundSet.traits.filter((trait: string) => traits.includes(trait));
-
-        for (const trait of matchingTraits) {
-            if (trait === "male" || trait === "female") {
-                score += GENDER_TRAIT_SCORE;
+        // Trait match
+        let totalTraitWeight = 0;
+        for (const traitEntry of soundSet.traits) {
+            if (Array.isArray(traitEntry)) {
+                // Multi-trait set: all traits in the set must match.
+                // Weight scales with set size: 1 + (n-1) * TRAIT_SET_SIZE_BONUS
+                const allMatched = traitEntry.every(t => traits.includes(t));
+                if (allMatched) {
+                    totalTraitWeight +=
+                        TRAIT_WEIGHT + (traitEntry.length - 1) * TRAIT_SET_SIZE_BONUS;
+                }
             } else {
-                score += TRAIT_SCORE;
+                // Single trait
+                if (traits.includes(traitEntry)) {
+                    if (traitEntry === "male" || traitEntry === "female") {
+                        totalTraitWeight += GENDER_TRAIT_WEIGHT;
+                    } else {
+                        totalTraitWeight += TRAIT_WEIGHT;
+                    }
+                }
             }
+        }
+
+        if (totalTraitWeight > 0) {
+            // Formula: 0.9 + 0.1 * totalTraitWeight (with a max of 1.9)
+            score += Math.min(
+                TRAIT_SET_MAX_SCORE,
+                TRAIT_SET_BASE_SCORE + TRAIT_SET_PER_TRAIT_SCORE * totalTraitWeight
+            );
         }
 
         // Size adjustment

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,8 +93,15 @@ function isSoundSet(obj: unknown): obj is SoundSet {
         isStringArray(obj.death_sounds) &&
         isStringArray(obj.creatures) &&
         isStringArray(obj.keywords) &&
-        isStringArray(obj.traits) &&
+        isTraitsArray(obj.traits) &&
         typeof obj.size === 'number'
+    );
+}
+
+function isTraitsArray(value: unknown): value is (string | string[])[] {
+    return Array.isArray(value) && value.every(item =>
+        typeof item === 'string' ||
+        (Array.isArray(item) && item.every(subItem => typeof subItem === 'string'))
     );
 }
 

--- a/tests/creaturesounds.test.ts
+++ b/tests/creaturesounds.test.ts
@@ -289,13 +289,15 @@ describe("Scoring Logic", () => {
         } as unknown as ActorPF2e;
 
         const scores = scoreSoundSets(femaleElf, mockDb);
-        // "set-female-elf": traits are humanoid (1), elf (1), female (0.5) => total 2.5
-        // Keyword in name "Elf" matches "elf" (+5) => total 7.5
-        expect(scores.get(mockDb["set-female-elf"])).toBe(7.5);
+        // "set-female-elf": traits are humanoid (1.0), elf (1.0), female (0.5) => total W = 2.5
+        // Trait score = Math.min(1.9, 0.9 + 0.1 * 2.5) = 1.15
+        // Keyword in name "Elf" matches "elf" (+5) => total 6.15
+        expect(scores.get(mockDb["set-female-elf"])).toBeCloseTo(6.15);
 
-        // "set-male-elf": traits are humanoid (1), elf (1), male (0) (since actor is female) => total 2
-        // Keyword in name "Elf" matches "elf" (+5) => total 7
-        expect(scores.get(mockDb["set-male-elf"])).toBe(7);
+        // "set-male-elf": traits are humanoid (1.0), elf (1.0), male (0) => total W = 2.0
+        // Trait score = Math.min(1.9, 0.9 + 0.1 * 2.0) = 1.1
+        // Keyword in name "Elf" matches "elf" (+5) => total 6.1
+        expect(scores.get(mockDb["set-male-elf"])).toBeCloseTo(6.1);
     });
 
     it("should apply size adjustment for non-zero scores", () => {
@@ -496,5 +498,99 @@ describe("Sound Type Selection (getSoundsOfType)", () => {
     it("should fall back to hurt sounds when death_sounds is empty", () => {
         const result = getSoundsOfType(mockDb["set-dragon-large"], "death");
         expect(result).toEqual(["dragon_hurt.wav"]);
+    });
+});
+
+describe("Multi-Trait Set Scoring Logic", () => {
+    const dbWithSets: SoundDatabase = {
+        "set-fire-elemental": {
+            id: "set-fire-elemental",
+            display_name: "Fire Elemental Sound Set",
+            category: "Elementals",
+            hurt_sounds: [], attack_sounds: [], death_sounds: [], creatures: [], keywords: [],
+            traits: [["elemental", "fire"]],
+            size: -1,
+        },
+        "set-mixed": {
+            id: "set-mixed",
+            display_name: "Mixed Sound Set",
+            category: "Humanoids",
+            hurt_sounds: [], attack_sounds: [], death_sounds: [], creatures: [], keywords: [],
+            traits: ["humanoid", ["elemental", "fire"]],
+            size: -1,
+        },
+    };
+
+    it("should score 0 if none of the traits in a multi-trait set match", () => {
+        const actor = {
+            type: "npc",
+            flags: { pf2e: { rollOptions: { all: { "self:trait:cold": true } } } },
+            system: { details: { blurb: "" } }
+        } as unknown as ActorPF2e;
+        const scores = scoreSoundSets(actor, dbWithSets);
+        expect(scores.get(dbWithSets["set-fire-elemental"])).toBe(0);
+    });
+
+    it("should score 0 if only some of the traits in a multi-trait set match", () => {
+        const actor = {
+            type: "npc",
+            flags: { pf2e: { rollOptions: { all: { "self:trait:elemental": true } } } },
+            system: { details: { blurb: "" } }
+        } as unknown as ActorPF2e;
+        const scores = scoreSoundSets(actor, dbWithSets);
+        expect(scores.get(dbWithSets["set-fire-elemental"])).toBe(0);
+    });
+
+    it("should weight a larger multi-trait set match higher than a smaller one", () => {
+        const actor = {
+            type: "npc",
+            flags: {
+                pf2e: {
+                    rollOptions: {
+                        all: {
+                            "self:trait:elemental": true,
+                            "self:trait:fire": true,
+                        }
+                    }
+                }
+            },
+            system: { details: { blurb: "" } }
+        } as unknown as ActorPF2e;
+        const scores = scoreSoundSets(actor, dbWithSets);
+        // 2-trait set: weight = 1 + (2-1)*0.1 = 1.1, score = min(1.9, 0.9 + 0.11) = 1.01
+        expect(scores.get(dbWithSets["set-fire-elemental"])).toBeCloseTo(1.01);
+    });
+
+    it("should score standard traits and multi-trait sets correctly when mixed", () => {
+        const actorHumanoidOnly = {
+            type: "npc",
+            flags: { pf2e: { rollOptions: { all: { "self:trait:humanoid": true } } } },
+            system: { details: { blurb: "" } }
+        } as unknown as ActorPF2e;
+
+        const actorAll = {
+            type: "npc",
+            flags: {
+                pf2e: {
+                    rollOptions: {
+                        all: {
+                            "self:trait:humanoid": true,
+                            "self:trait:elemental": true,
+                            "self:trait:fire": true,
+                        }
+                    }
+                }
+            },
+            system: { details: { blurb: "" } }
+        } as unknown as ActorPF2e;
+
+        // 1. Only "humanoid" matches (W = 1.0) => score is 1.0
+        const scores1 = scoreSoundSets(actorHumanoidOnly, dbWithSets);
+        expect(scores1.get(dbWithSets["set-mixed"])).toBe(1.0);
+
+        // 2. Both "humanoid" (W=1.0) and ["elemental","fire"] (W=1.1) match
+        //    => total W=2.1, score = min(1.9, 0.9 + 0.21) = 1.11
+        const scores2 = scoreSoundSets(actorAll, dbWithSets);
+        expect(scores2.get(dbWithSets["set-mixed"])).toBeCloseTo(1.11);
     });
 });

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -100,6 +100,26 @@ describe("Schema Validation (isSoundDatabase)", () => {
         };
         expect(isSoundDatabase(invalidDb)).toBe(false);
     });
+
+    it("should accept entries with nested string arrays in traits", () => {
+        const nestedDb = {
+            "Custom-X": {
+                ...validSoundSet, id: "Custom-X", traits: ["humanoid", ["elemental", "fire"]],
+            },
+        };
+        expect(isSoundDatabase(nestedDb)).toBe(true);
+    });
+
+    it("should reject entries with invalid nesting or non-string elements in traits", () => {
+        const invalidDb1 = {
+            "Custom-X": { ...validSoundSet, id: "Custom-X", traits: ["humanoid", [["elemental"]]] },
+        };
+        const invalidDb2 = {
+            "Custom-X": { ...validSoundSet, id: "Custom-X", traits: ["humanoid", [123]] },
+        };
+        expect(isSoundDatabase(invalidDb1)).toBe(false);
+        expect(isSoundDatabase(invalidDb2)).toBe(false);
+    });
 });
 
 describe("Custom Database Validation (validateCustomSoundDatabase)", () => {


### PR DESCRIPTION
Allow sets of traits to be added to sound sets for matching.

All traits within a set must be present for there to be a match.

Sets of traits score slightly higher than single traits.

Trait scoring also updated so traits can only contribute up to 1.9 score, so always lower than a keyword match.